### PR TITLE
Update transport port to 443

### DIFF
--- a/service.go
+++ b/service.go
@@ -124,7 +124,7 @@ func NewService(options *Options, connectionOptions *ConnectionOptions) (Elarian
 
 	srvc := &service{
 		host:                         "tcp.elarian.dev",
-		port:                         8082,
+		port:                         443,
 		errorChannel:                 errorChan,
 		replyChannel:                 replyChan,
 		notificationChannel:          notificationChannel,

--- a/test/service_test.go
+++ b/test/service_test.go
@@ -1,0 +1,22 @@
+package test
+
+import (
+	elarian "github.com/elarianltd/go-sdk"
+	"github.com/stretchr/testify/assert"
+	"log"
+	"testing"
+)
+
+func Test_NewService(t *testing.T) {
+	t.Run("Should connect to elarian successfully", func(t *testing.T) {
+		service, err := elarian.Connect(GetOpts())
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		defer service.Disconnect()
+
+		assert.NoError(t, err)
+		assert.NotNil(t, service)
+	})
+}


### PR DESCRIPTION
Fixes [#3](https://github.com/ElarianLtd/go-sdk/issues/3)

Change the port from `8082` to `443` as per the sdk-spec.